### PR TITLE
fix hostname not being parsed properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,21 +85,7 @@ If you want to see what the exporter returns, you can access :
 
 ## Grafana dashboards
 
-Is there a Grafana dashboard available ? Of course!
-You can have a "global" dashboard with all the servers you want to monitor (status, CPU, netin/out) and a "per server" dashboard with all the metrics you want to monitor (players, users, etc.)
-
-**Counter Strike: Global Offensive** : https://grafana.com/grafana/dashboards/11333
-
-**Counter Strike: Source** : Coming
-
-**Garry's Mod** : Coming
-
-**Half Life 2** : Coming
-
-**Left 4 Dead 2** : Coming
-
-**Team Fortress 2** : Coming
-
+Grafana dashboards are being revamped and should be available soon!
 
 ### Support
 

--- a/games/csgo.js
+++ b/games/csgo.js
@@ -11,8 +11,9 @@ const formatRconResult = function (result) {
     stats = stats[0].trim().split(/\s+/);
 
     const infosArray = status.split(/\r?\n/);
+
     status = {
-        hostname: infosArray[0].split(': ')[1],
+        hostname: infosArray[0].split(': ').slice(1).join(': '),
         version: infosArray[1].split(': ')[1].split('/')[0],
         map: infosArray[5].split(': ')[1],
     }

--- a/games/css.js
+++ b/games/css.js
@@ -12,7 +12,7 @@ const formatRconResult = function (result) {
     const infosArray = status.split(/\r?\n/);
 
     status = {
-        hostname: infosArray[0].split(': ')[1],
+        hostname: infosArray[0].split(': ').slice(1).join(': '),
         version: infosArray[1].split(': ')[1].split('/')[0],
         map: infosArray[4].split(': ')[1].split(' ')[0],
     }

--- a/games/gmod.js
+++ b/games/gmod.js
@@ -12,7 +12,7 @@ const formatRconResult = function (result) {
     const infosArray = status.split(/\r?\n/);
 
     status = {
-        hostname: infosArray[0].split(': ')[1],
+        hostname: infosArray[0].split(': ').slice(1).join(': '),
         version: infosArray[1].split(': ')[1].split('/')[0],
         map: infosArray[3].split(': ')[1].split(' ')[0],
     }

--- a/games/hl2.js
+++ b/games/hl2.js
@@ -12,7 +12,7 @@ const formatRconResult = function (result) {
     const infosArray = status.split(/\r?\n/);
 
     status = {
-        hostname: infosArray[0].split(': ')[1],
+        hostname: infosArray[0].split(': ').slice(1).join(': '),
         version: infosArray[1].split(': ')[1].split('/')[0],
         map: infosArray[4].split(': ')[1].split(' ')[0],
     }

--- a/games/l4d2.js
+++ b/games/l4d2.js
@@ -12,7 +12,7 @@ const formatRconResult = function (result) {
     const infosArray = status.split(/\r?\n/);
 
     status = {
-        hostname: infosArray[0].split(': ')[1],
+        hostname: infosArray[0].split(': ').slice(1).join(': '),
         version: infosArray[1].split(': ')[1].split(' ')[0],
         map: infosArray[4].split(': ')[1].split(' ')[0],
     }

--- a/games/tf2.js
+++ b/games/tf2.js
@@ -12,7 +12,7 @@ const formatRconResult = function (result) {
     const infosArray = status.split(/\r?\n/);
 
     status = {
-        hostname: infosArray[0].split(': ')[1],
+        hostname: infosArray[0].split(': ').slice(1).join(': '),
         version: infosArray[1].split(': ')[1].split('/')[0],
         map: infosArray[5].split(': ')[1].split(' ')[0],
     }

--- a/index.js
+++ b/index.js
@@ -27,19 +27,18 @@ app.get('/metrics', validator.query(metricsParamsSchema), async (req, res) => {
     const { ip, port, password, game } = req.query;
 
     try {
-        const client = await connect(ip, port, password, 5000);
+        const client = await connect(ip, port, password, 30 * 1000);
 
         const status = await client.command('status');
         const stats = await client.command('stats');
 
         await client.disconnect();
-
         const response = games[game].setMetrics({ stats, status }, { ip, port, game });
 
         res.end(response);
     } catch (err) {
+        logger.error({ step: 'FETCH_METRICS', err: err.message }, 'error while fetching metrics from server');
         const response = games[game].setNoMetrics({ ip, port, game });
-
         res.end(response);
     }
 });

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ app.get('/metrics', validator.query(metricsParamsSchema), async (req, res) => {
     const { ip, port, password, game } = req.query;
 
     try {
-        const client = await connect(ip, port, password, 30 * 1000);
+        const client = await connect(ip, port, password, 5 * 1000);
 
         const status = await client.command('status');
         const stats = await client.command('stats');


### PR DESCRIPTION
Allows to have the hostname label containing the full hostname in case it contains `: ` in the name

for example, default CSGO hostname is `Counter Strike: Global Offensive` which will now completely appear as label : 

```
# HELP srcds_status The server's status, 0 = offline/bad password, 1 = online
# TYPE srcds_status gauge
srcds_status{server="<redacted>:27015",game="csgo",version="1.38.4.8",hostname="Counter-Strike: Global Offensive",map="de_dust2"} 1
```

Closes #12 